### PR TITLE
Fix broken environment in the docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     image: nginx:stable-alpine
     environment:
       - PPR_BASE
+      - NGINX_PORT=80
     depends_on:
       - apt-repo
     volumes:
@@ -23,8 +24,6 @@ services:
       - ./nginx-conf/nginx.conf:/etc/nginx/nginx.conf
     ports:
       - "80:80"
-    environment:
-      - NGINX_PORT=80
     logging:
       options:
         max-size: 10m


### PR DESCRIPTION
Otherwise, I get an error about having environment defined twice. Even if there is no error on your end, it makes it much cleaner.